### PR TITLE
Define fallback values in case properties are undefined

### DIFF
--- a/src/js/helper/tastify.js
+++ b/src/js/helper/tastify.js
@@ -30,13 +30,13 @@ const availableSelectors = {
         return state.wishlist?.wishlist || emptyEntity
     },
     notifications: (state) => {
-        return state.user.notifications
+        return state.user?.notifications || emptyEntity
     },
     deviceType: (state) => {
-        return state.renderContext.deviceType
+        return state.renderContext?.deviceType || emptyEntity
     },
     isServerSideRendering: (state) => {
-        return state.renderContext.serverSideRendering
+        return state.renderContext?.serverSideRendering || emptyEntity
     },
     route: (state) => {
         return state.app?.route


### PR DESCRIPTION
We need to handle undefined properties to be able to prevent javascript runtime errors in Storybook.
for example when running `tastify()` with `isServerSideRendering`, there will be an error throwen.
Which is located [here](https://github.com/FrontasticGmbH/catwalk/blob/55617dde27839c5e2be6d638295f1265f0c31d1b/src/js/helper/tastify.js#L38-L40)
<img width="567" alt="Bildschirmfoto 2020-12-08 um 09 26 12" src="https://user-images.githubusercontent.com/63041505/101458896-c968b880-3937-11eb-8d12-e4f20e3b7eec.png">