### PR TITLE
Use Authenticator interface

### DIFF
--- a/src/php/FrontendBundle/Controller/AccountAuthController.php
+++ b/src/php/FrontendBundle/Controller/AccountAuthController.php
@@ -4,7 +4,6 @@ namespace Frontastic\Catwalk\FrontendBundle\Controller;
 
 use Assert\Assertion;
 use Frontastic\Catwalk\ApiCoreBundle\Domain\Context;
-use Frontastic\Catwalk\FrontendBundle\Security\Authenticator;
 use Frontastic\Catwalk\TrackingBundle\Domain\TrackingService;
 use Frontastic\Common\AccountApiBundle\Domain\Account;
 use Frontastic\Common\AccountApiBundle\Domain\AccountService;
@@ -20,6 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\LogoutException;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Guard\AuthenticatorInterface;
 use Symfony\Component\Security\Guard\GuardAuthenticatorHandler;
 
 /**
@@ -30,7 +30,7 @@ class AccountAuthController
 {
     private TrackingService $trackingService;
     private AccountService $accountService;
-    private Authenticator $authenticator;
+    private AuthenticatorInterface $authenticator;
     private CartFetcher $cartFetcher;
     private GuardAuthenticatorHandler $guardAuthenticatorHandler;
     private Logger $logger;
@@ -38,7 +38,7 @@ class AccountAuthController
     public function __construct(
         TrackingService $trackingService,
         AccountService $accountService,
-        Authenticator $authenticator,
+        AuthenticatorInterface $authenticator,
         CartFetcher $cartFetcher,
         GuardAuthenticatorHandler $guardAuthenticatorHandler,
         Logger $logger


### PR DESCRIPTION
The usage of the concrete class forces you always to extend from this class instead of using the decorator principle and implement against the interface. with this change nothing changes as the guard authenticator handler also only expect an interface